### PR TITLE
Add `UnliftIO` variant

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,12 @@
 
 ## Unreleased changes
 
+## 0.1.2.0
+
+- [#]()
+    - Add `Control.Exception.Annotated.UnliftIO` that uses `MonadUnliftIO`
+      instead of `MonadCatch` and `MonadThrow`.
+
 ## 0.1.1.0
 
 - [#4](https://github.com/parsonsmatt/annotated-exception/pull/4)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,9 +4,10 @@
 
 ## 0.1.2.0
 
-- [#]()
+- [#6](https://github.com/parsonsmatt/annotated-exception/pull/6)
     - Add `Control.Exception.Annotated.UnliftIO` that uses `MonadUnliftIO`
       instead of `MonadCatch` and `MonadThrow`.
+    - Actually expose `catches`
 
 ## 0.1.1.0
 

--- a/annotated-exception.cabal
+++ b/annotated-exception.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           annotated-exception
-version:        0.1.1.0
+version:        0.1.2.0
 synopsis:       Exceptions, with checkpoints and context.
 description:    Please see the README on Github at <https://github.com/parsonsmatt/annotated-exception#readme>
 category:       Control
@@ -28,6 +28,7 @@ source-repository head
 library
   exposed-modules:
       Control.Exception.Annotated
+      Control.Exception.Annotated.UnliftIO
       Data.Annotation
   other-modules:
       Paths_annotated_exception
@@ -39,6 +40,7 @@ library
     , containers
     , safe-exceptions
     , text
+    , unliftio-core
   default-language: Haskell2010
 
 test-suite annotated-exception-test
@@ -60,4 +62,5 @@ test-suite annotated-exception-test
     , hspec
     , safe-exceptions
     , text
+    , unliftio-core
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                annotated-exception
-version:             0.1.1.0
+version:             0.1.2.0
 github:              "parsonsmatt/annotated-exception"
 license:             BSD3
 author:              "Matt Parsons"
@@ -24,6 +24,7 @@ dependencies:
 - safe-exceptions
 - containers
 - text
+- unliftio-core
 
 library:
   source-dirs: src

--- a/src/Control/Exception/Annotated.hs
+++ b/src/Control/Exception/Annotated.hs
@@ -37,6 +37,7 @@ module Control.Exception.Annotated
     , checkpointCallStackWith
     -- * Handling Exceptions
     , catch
+    , catches
     , tryAnnotated
     , try
 
@@ -183,7 +184,7 @@ catch action handler =
 -- | Like 'Safe.catches', but this function enhance the provided 'Handler's
 -- to "see through" any 'AnnotatedException's.
 --
--- @since 0.1.1.0
+-- @since 0.1.2.0
 catches :: (MonadCatch m) => m a -> [Handler m a] -> m a
 catches action handlers =
     Safe.catches action (mkAnnotatedHandlers handlers)

--- a/src/Control/Exception/Annotated/UnliftIO.hs
+++ b/src/Control/Exception/Annotated/UnliftIO.hs
@@ -37,12 +37,19 @@ module Control.Exception.Annotated.UnliftIO
     , MonadUnliftIO(..)
     ) where
 
-import qualified Control.Exception.Safe as Safe
 import Control.Exception.Annotated hiding
-    (throwWithCallStack
-    , checkpoint, checkpointCallStackWith, checkpointMany, catch, catches, try,
-    tryAnnotated, throw)
+       ( catch
+       , catches
+       , checkpoint
+       , checkpointCallStackWith
+       , checkpointMany
+       , throw
+       , throwWithCallStack
+       , try
+       , tryAnnotated
+       )
 import qualified Control.Exception.Annotated as Catch
+import qualified Control.Exception.Safe as Safe
 import Control.Monad.IO.Unlift
 import GHC.Stack
 

--- a/src/Control/Exception/Annotated/UnliftIO.hs
+++ b/src/Control/Exception/Annotated/UnliftIO.hs
@@ -15,6 +15,7 @@ module Control.Exception.Annotated.UnliftIO
     , checkpointCallStackWith
     -- * Handling Exceptions
     , catch
+    , catches
     , tryAnnotated
     , try
 
@@ -120,3 +121,17 @@ try
 try action =
     withRunInIO $ \runInIO ->
         liftIO $ Catch.try (runInIO action)
+
+-- | Like 'Catch.catches', bt uses 'MonadUnliftIO' instead of 'MonadCatch'.
+--
+-- @since 0.1.2.0
+catches
+    :: MonadUnliftIO m
+    => m a
+    -> [Handler m a]
+    -> m a
+catches action handlers =
+    withRunInIO $ \runInIO -> do
+        let f (Handler k) = Handler (\e -> runInIO (k e))
+        liftIO $ catches (runInIO action) (map f handlers)
+  where

--- a/src/Control/Exception/Annotated/UnliftIO.hs
+++ b/src/Control/Exception/Annotated/UnliftIO.hs
@@ -1,0 +1,122 @@
+-- | This module presents the same interface as
+-- "Control.Exception.Annotated", but uses 'MonadUnliftIO' instead of
+-- 'MonadCatch' or 'MonadThrow'.
+--
+-- @since 0.1.2.0
+module Control.Exception.Annotated.UnliftIO
+    ( -- * The Main Type
+      AnnotatedException(..)
+    , new
+    , throwWithCallStack
+    -- * Annotating Exceptions
+    , checkpoint
+    , checkpointMany
+    , checkpointCallStack
+    , checkpointCallStackWith
+    -- * Handling Exceptions
+    , catch
+    , tryAnnotated
+    , try
+
+    -- * Manipulating Annotated Exceptions
+    , check
+    , hide
+    , annotatedExceptionCallStack
+    , addCallStackToException
+
+    -- * Re-exports from "Data.Annotation"
+    , Annotation(..)
+    , CallStackAnnotation(..)
+    -- * Re-exports from "Control.Exception.Safe"
+    , Exception(..)
+    , Safe.SomeException(..)
+    , throw
+    , Handler (..)
+    , MonadIO(..)
+    , MonadUnliftIO(..)
+    ) where
+
+import qualified Control.Exception.Safe as Safe
+import Control.Exception.Annotated hiding
+    (throwWithCallStack
+    , checkpoint, checkpointCallStackWith, checkpointMany, catch, catches, try,
+    tryAnnotated, throw)
+import qualified Control.Exception.Annotated as Catch
+import Control.Monad.IO.Unlift
+import GHC.Stack
+
+-- | Like 'Catch.throwWithCallStack', but uses 'MonadIO' instead of
+-- 'MonadThrow'.
+--
+-- @since 0.1.2.0
+throwWithCallStack
+    :: (MonadIO m, Exception e, HasCallStack)
+    => e -> m a
+throwWithCallStack = liftIO . Catch.throwWithCallStack
+
+-- | Like 'Catch.throw', but uses 'MonadIO' instead of 'MonadThrow'.
+--
+-- @since 0.1.2.0
+throw :: (MonadIO m, Exception e) => e -> m a
+throw = liftIO . Catch.throw
+
+-- | Like 'Catch.checkpoint', but uses 'MonadUnliftIO' instead of 'MonadCatch'.
+--
+-- @since 0.1.2.0
+checkpoint :: (MonadUnliftIO m) => Annotation -> m a -> m a
+checkpoint ann action = withRunInIO $ \runInIO ->
+    liftIO $ Catch.checkpoint ann (runInIO action)
+
+-- | Like 'Catch.checkpointMany', but uses 'MonadUnliftIO' instead of
+-- 'MonadCatch'.
+--
+-- @since 0.1.2.0
+checkpointMany :: (MonadUnliftIO m) => [Annotation] -> m a -> m a
+checkpointMany anns action =
+    withRunInIO $ \runInIO ->
+        liftIO $ Catch.checkpointMany anns (runInIO action)
+
+-- | Like 'Catch.checkpointCallStackWith', but uses 'MonadUnliftIO' instead of
+-- 'MonadCatch'.
+--
+-- @since 0.1.2.0
+checkpointCallStackWith
+    :: (MonadUnliftIO m, HasCallStack)
+    => [Annotation] -> m a -> m a
+checkpointCallStackWith anns action =
+    withRunInIO $ \runInIO ->
+        liftIO $ Catch.checkpointCallStackWith anns (runInIO action)
+
+-- | Like 'Catch.catch', but uses 'MonadUnliftIO' instead of 'MonadCatch'.
+--
+-- @since 0.1.2.0
+catch
+    :: (MonadUnliftIO m, Exception e)
+    => m a
+    -> (e -> m a)
+    -> m a
+catch action handler =
+    withRunInIO $ \runInIO ->
+        liftIO $ Catch.catch (runInIO action) (\e -> runInIO $ handler e)
+
+-- | Like 'Catch.tryAnnotated' but uses 'MonadUnliftIO' instead of 'MonadCatch'.
+--
+-- @since 0.1.2.0
+tryAnnotated
+    :: (MonadUnliftIO m, Exception e)
+    => m a
+    -> m (Either (AnnotatedException e) a)
+tryAnnotated action =
+    withRunInIO $ \runInIO ->
+        liftIO $ Catch.tryAnnotated (runInIO action)
+
+-- | Like 'Catch.try' but uses 'MonadUnliftIO' instead of 'MonadCatch'.
+--
+-- @since 0.1.2.0
+try
+    :: (MonadUnliftIO m, Exception e)
+    => m a
+    -> m (Either e a)
+try action =
+    withRunInIO $ \runInIO ->
+        liftIO $ Catch.try (runInIO action)

--- a/src/Control/Exception/Annotated/UnliftIO.hs
+++ b/src/Control/Exception/Annotated/UnliftIO.hs
@@ -1,3 +1,5 @@
+{-# language ExplicitForAll #-}
+
 -- | This module presents the same interface as
 -- "Control.Exception.Annotated", but uses 'MonadUnliftIO' instead of
 -- 'MonadCatch' or 'MonadThrow'.
@@ -58,20 +60,20 @@ import GHC.Stack
 --
 -- @since 0.1.2.0
 throwWithCallStack
-    :: (MonadIO m, Exception e, HasCallStack)
+    :: forall e m a. (MonadIO m, Exception e, HasCallStack)
     => e -> m a
 throwWithCallStack = liftIO . Catch.throwWithCallStack
 
 -- | Like 'Catch.throw', but uses 'MonadIO' instead of 'MonadThrow'.
 --
 -- @since 0.1.2.0
-throw :: (MonadIO m, Exception e) => e -> m a
+throw :: forall e m a. (MonadIO m, Exception e) => e -> m a
 throw = liftIO . Catch.throw
 
 -- | Like 'Catch.checkpoint', but uses 'MonadUnliftIO' instead of 'MonadCatch'.
 --
 -- @since 0.1.2.0
-checkpoint :: (MonadUnliftIO m) => Annotation -> m a -> m a
+checkpoint :: forall m a. (MonadUnliftIO m) => Annotation -> m a -> m a
 checkpoint ann action = withRunInIO $ \runInIO ->
     liftIO $ Catch.checkpoint ann (runInIO action)
 
@@ -79,7 +81,7 @@ checkpoint ann action = withRunInIO $ \runInIO ->
 -- 'MonadCatch'.
 --
 -- @since 0.1.2.0
-checkpointMany :: (MonadUnliftIO m) => [Annotation] -> m a -> m a
+checkpointMany :: forall m a. (MonadUnliftIO m) => [Annotation] -> m a -> m a
 checkpointMany anns action =
     withRunInIO $ \runInIO ->
         liftIO $ Catch.checkpointMany anns (runInIO action)
@@ -89,7 +91,7 @@ checkpointMany anns action =
 --
 -- @since 0.1.2.0
 checkpointCallStackWith
-    :: (MonadUnliftIO m, HasCallStack)
+    :: forall m a. (MonadUnliftIO m, HasCallStack)
     => [Annotation] -> m a -> m a
 checkpointCallStackWith anns action =
     withRunInIO $ \runInIO ->
@@ -99,7 +101,7 @@ checkpointCallStackWith anns action =
 --
 -- @since 0.1.2.0
 catch
-    :: (MonadUnliftIO m, Exception e)
+    :: forall e m a. (MonadUnliftIO m, Exception e)
     => m a
     -> (e -> m a)
     -> m a
@@ -111,7 +113,7 @@ catch action handler =
 --
 -- @since 0.1.2.0
 tryAnnotated
-    :: (MonadUnliftIO m, Exception e)
+    :: forall e m a. (MonadUnliftIO m, Exception e)
     => m a
     -> m (Either (AnnotatedException e) a)
 tryAnnotated action =
@@ -122,7 +124,7 @@ tryAnnotated action =
 --
 -- @since 0.1.2.0
 try
-    :: (MonadUnliftIO m, Exception e)
+    :: forall e m a. (MonadUnliftIO m, Exception e)
     => m a
     -> m (Either e a)
 try action =
@@ -133,7 +135,7 @@ try action =
 --
 -- @since 0.1.2.0
 catches
-    :: MonadUnliftIO m
+    :: forall m a. MonadUnliftIO m
     => m a
     -> [Handler m a]
     -> m a

--- a/test/Control/Exception/AnnotatedSpec.hs
+++ b/test/Control/Exception/AnnotatedSpec.hs
@@ -114,6 +114,14 @@ spec = do
                     exn `shouldBe` TestException
             action `shouldThrow` (== new TestException)
 
+    describe "catches" $ do
+        it "is exported" $ do
+            let
+                _x :: IO a -> [Handler IO a] -> IO a
+                _x = catches
+            pass
+
+
     describe "checkpoint" $ do
         it "adds annotations" $ do
             Left exn <- try (checkpoint "Here" (throw TestException))


### PR DESCRIPTION
This PR adds a variant of the API that uses `MonadUnliftIO` instead of `MonadCatch` and `MonadThrow`. Mostly because that's how we roll at work.

Before submitting your PR, check that you've:

- [x] Bumped the version number.
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html).
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock.
- [x] Ran `stylish-haskell` and otherwise adhered to the [style guide](https://github.com/bitemyapp/esqueleto/blob/master/style-guide.yaml).

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR.
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts).

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_

If you're unsure on what the new version number should be, feel free to ask.

-->
