### PR TITLE
Fix the checkpointCallStack from MonadUnliftIO module

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        cabal: ["3.4"]
+        cabal: ["3.6"]
         ghc: ["8.6.5", "8.8.4", "8.10.7", "9.0.2", "9.2.2"]
     env:
       CONFIG: "--enable-tests"

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -25,15 +25,15 @@ jobs:
           cabal-version: ${{ matrix.cabal }}
       - run: cabal v2-update
       - run: cabal v2-freeze $CONFIG
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
-            dist-newstyle
-          key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
-            ${{ runner.os }}-${{ matrix.ghc }}-
+        #       - uses: actions/cache@v2
+        #         with:
+        #           path: |
+        #             ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
+        #             dist-newstyle
+        #           key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
+        #           restore-keys: |
+        #             ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
+        #             ${{ runner.os }}-${{ matrix.ghc }}-
       - run: cabal v2-build --disable-optimization -j $CONFIG
       - run: cabal v2-test --disable-optimization -j $CONFIG
       - run: cabal v2-haddock -j $CONFIG

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## 0.2.0.2
 
-- [#]()
+- [#14](https://github.com/parsonsmatt/annotated-exception/pull/14)
     - Define `Control.Exception.Annotated.UnliftIO.checkpointCallStack` without
       re-exporting the `MonadCatch` variant. Sigh.
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,10 @@
-# Changelog for located-exception
+# Changelog for `annotated-exception`
 
-## Unreleased changes
+## 0.2.0.2
+
+- [#]()
+    - Define `Control.Exception.Annotated.UnliftIO.checkpointCallStack` without
+      re-exporting the `MonadCatch` variant. Sigh.
 
 ## 0.2.0.1
 

--- a/annotated-exception.cabal
+++ b/annotated-exception.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           annotated-exception
-version:        0.2.0.1
+version:        0.2.0.2
 synopsis:       Exceptions, with checkpoints and context.
 description:    Please see the README on Github at <https://github.com/parsonsmatt/annotated-exception#readme>
 category:       Control

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                annotated-exception
-version:             0.2.0.1
+version:             0.2.0.2
 github:              "parsonsmatt/annotated-exception"
 license:             BSD3
 author:              "Matt Parsons"

--- a/src/Control/Exception/Annotated/UnliftIO.hs
+++ b/src/Control/Exception/Annotated/UnliftIO.hs
@@ -39,16 +39,17 @@ module Control.Exception.Annotated.UnliftIO
     , MonadUnliftIO(..)
     ) where
 
-import Control.Exception.Annotated hiding
-       ( catch
-       , catches
-       , checkpoint
-       , checkpointCallStackWith
-       , checkpointMany
-       , throw
-       , throwWithCallStack
-       , try
-       , tryAnnotated
+import Control.Exception.Annotated
+       ( AnnotatedException(..)
+       , Annotation(..)
+       , CallStackAnnotation(..)
+       , Exception(..)
+       , Handler(..)
+       , addCallStackToException
+       , annotatedExceptionCallStack
+       , check
+       , exceptionWithCallStack
+       , hide
        )
 import qualified Control.Exception.Annotated as Catch
 import qualified Control.Exception.Safe as Safe
@@ -76,6 +77,18 @@ throw = liftIO . withFrozenCallStack Catch.throw
 checkpoint :: forall m a. (MonadUnliftIO m, HasCallStack) => Annotation -> m a -> m a
 checkpoint ann action = withRunInIO $ \runInIO ->
     liftIO $ withFrozenCallStack (Catch.checkpoint ann) (runInIO action)
+
+-- | Like 'Catch.checkpointCallStack', but uses 'MonadUnliftIO' instead of
+-- 'Control.Monad.Catch.MonadCatch'.
+--
+-- @since 0.2.0.2
+checkpointCallStack
+    :: forall m a. (MonadUnliftIO m, HasCallStack)
+    => m a
+    -> m a
+checkpointCallStack action =
+    withRunInIO $ \runInIO ->
+        withFrozenCallStack Catch.checkpointCallStack (runInIO action)
 
 -- | Like 'Catch.checkpointMany', but uses 'MonadUnliftIO' instead of
 -- 'Control.Monad.Catch.MonadCatch'.

--- a/test/Control/Exception/Annotated/UnliftIOSpec.hs
+++ b/test/Control/Exception/Annotated/UnliftIOSpec.hs
@@ -1,3 +1,5 @@
+{-# language RecordWildCards, StrictData, RankNTypes #-}
+
 module Control.Exception.Annotated.UnliftIOSpec where
 
 import Test.Hspec


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [x] Bumped the version number.
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html).
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock.
- [x] Ran `stylish-haskell` and otherwise adhered to the [style guide](https://github.com/bitemyapp/esqueleto/blob/master/style-guide.yaml).

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR.
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts).

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_

If you're unsure on what the new version number should be, feel free to ask.

-->
