### PR TITLE
add withFrozenCallStack to checkpointMany

### DIFF
--- a/src/Control/Exception/Annotated.hs
+++ b/src/Control/Exception/Annotated.hs
@@ -318,7 +318,7 @@ checkpointCallStack =
 --
 -- @since 0.1.0.0
 checkpointMany :: (MonadCatch m, HasCallStack) => [Annotation] -> m a -> m a
-checkpointMany anns action =
+checkpointMany anns action = withFrozenCallStack $
     action `Safe.catch` \(exn :: SomeException) ->
         Safe.throw
             . addCallStackToException callStack


### PR DESCRIPTION
checkpointMany is part of the intended user-facing API, so just like
checkpoint, we don't want it to appear in the stack trace.

Before submitting your PR, check that you've:

- [ ] Bumped the version number.
- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html).
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock.
- [ ] Ran `stylish-haskell` and otherwise adhered to the [style guide](https://github.com/bitemyapp/esqueleto/blob/master/style-guide.yaml).

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR.
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts).

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_

If you're unsure on what the new version number should be, feel free to ask.

-->
