### PR TITLE
Add `HasCallStack` to `catch` et al

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## 0.2.0.3
 
-- []()
+- [#17](https://github.com/parsonsmatt/annotated-exception/pull/17)
     - Add `HasCallStack` to `catch` and `catches`
 
 ## 0.2.0.2

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog for `annotated-exception`
 
+## 0.2.0.3
+
+- []()
+    - Add `HasCallStack` to `catch` and `catches`
+
 ## 0.2.0.2
 
 - [#14](https://github.com/parsonsmatt/annotated-exception/pull/14)

--- a/annotated-exception.cabal
+++ b/annotated-exception.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           annotated-exception
-version:        0.2.0.2
+version:        0.2.0.3
 synopsis:       Exceptions, with checkpoints and context.
 description:    Please see the README on Github at <https://github.com/parsonsmatt/annotated-exception#readme>
 category:       Control

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                annotated-exception
-version:             0.2.0.2
+version:             0.2.0.3
 github:              "parsonsmatt/annotated-exception"
 license:             BSD3
 author:              "Matt Parsons"

--- a/src/Control/Exception/Annotated.hs
+++ b/src/Control/Exception/Annotated.hs
@@ -183,23 +183,23 @@ check = traverse Safe.fromException
 -- >     putStrLn "ok!"
 --
 -- @since 0.1.0.0
-catch :: (Exception e, MonadCatch m) => m a -> (e -> m a) -> m a
+catch :: (HasCallStack, Exception e, MonadCatch m) => m a -> (e -> m a) -> m a
 catch action handler =
-    catches action [Handler handler]
+    withFrozenCallStack catches action [Handler handler]
 
 -- | Like 'Safe.catches', but this function enhance the provided 'Handler's
 -- to "see through" any 'AnnotatedException's.
 --
 -- @since 0.1.2.0
-catches :: (MonadCatch m) => m a -> [Handler m a] -> m a
+catches :: (MonadCatch m, HasCallStack) => m a -> [Handler m a] -> m a
 catches action handlers =
-    Safe.catches action (mkAnnotatedHandlers handlers)
+    Safe.catches action (withFrozenCallStack mkAnnotatedHandlers handlers)
 
 -- | Extends each 'Handler' in the list with a variant that sees through
 -- the 'AnnotatedException' and re-annotates any rethrown exceptions.
 --
 -- @since 0.1.1.0
-mkAnnotatedHandlers :: MonadCatch m => [Handler m a] -> [Handler m a]
+mkAnnotatedHandlers :: (HasCallStack, MonadCatch m) => [Handler m a] -> [Handler m a]
 mkAnnotatedHandlers xs =
     xs >>= \(Handler hndlr) ->
         [ Handler hndlr

--- a/test/Control/Exception/Annotated/UnliftIOSpec.hs
+++ b/test/Control/Exception/Annotated/UnliftIOSpec.hs
@@ -1,4 +1,4 @@
-{-# language RecordWildCards, StrictData, RankNTypes #-}
+{-# language ScopedTypeVariables, RecordWildCards, StrictData, RankNTypes #-}
 
 module Control.Exception.Annotated.UnliftIOSpec where
 
@@ -10,7 +10,10 @@ import Data.Annotation
 import GHC.Stack
 
 import Data.AnnotationSpec ()
-import Control.Exception.AnnotatedSpec (TestException(..))
+import Control.Exception.AnnotatedSpec
+    ( TestException(..)
+    , callStackFunctionNamesShouldBe
+    )
 import Data.Maybe
 
 asIO :: IO a -> IO a
@@ -34,8 +37,42 @@ spec = do
                                 expectationFailure "Should not catch"
                 action `shouldThrow` \(AnnotatedException _ e) ->
                     e == userError "oh no"
-
+        it "includes a callstack location" $ do
+            let
+                action =
+                    throw TestException
+                        `catch`
+                            \TestException ->
+                                throw TestException
+            action
+                `Safe.catch`
+                        \(e :: AnnotatedException TestException) -> do
+                            annotations e
+                                `callStackFunctionNamesShouldBe`
+                                    [ "throw"
+                                    , "throw"
+                                    , "catch"
+                                    ]
     describe "catches" $ do
+        it "has a callstack entry" $ do
+            let
+                action =
+                    throw TestException
+                        `catches`
+                            [ Handler $ \TestException ->
+                                throw TestException
+                            ]
+            action
+                `Safe.catch`
+                        \(e :: AnnotatedException TestException) -> do
+                            annotations e
+                                `callStackFunctionNamesShouldBe`
+                                    [ "throw"
+                                    , "throw"
+                                    , "catches"
+                                    ]
+
+
         describe "the right exception" $ do
             it "works" $ asIO $ do
                 throw TestException

--- a/test/Control/Exception/AnnotatedSpec.hs
+++ b/test/Control/Exception/AnnotatedSpec.hs
@@ -105,6 +105,40 @@ spec = do
             action
                 `shouldThrow`
                     (userError "uh oh" ==)
+        it "includes a callstack location" $ do
+            let
+                action =
+                    throw TestException
+                        `catch`
+                            \TestException ->
+                                throw TestException
+            action
+                `Safe.catch`
+                        \(e :: AnnotatedException TestException) -> do
+                            annotations e
+                                `callStackFunctionNamesShouldBe`
+                                    [ "throw"
+                                    , "throw"
+                                    , "catch"
+                                    ]
+    describe "catches" $ do
+        it "has a callstack entry" $ do
+            let
+                action =
+                    throw TestException
+                        `catches`
+                            [ Handler $ \TestException ->
+                                throw TestException
+                            ]
+            action
+                `Safe.catch`
+                        \(e :: AnnotatedException TestException) -> do
+                            annotations e
+                                `callStackFunctionNamesShouldBe`
+                                    [ "throw"
+                                    , "throw"
+                                    , "catches"
+                                    ]
 
     describe "tryAnnotated" $ do
         let subject :: (Exception e, Exception e') => e -> IO (AnnotatedException e')
@@ -153,7 +187,7 @@ spec = do
                     `Safe.catch` \(e :: AnnotatedException TestException) -> do
                         annotations e
                             `callStackFunctionNamesShouldBe`
-                                ["throwWithCallStack"
+                                [ "throwWithCallStack"
                                 , "checkpointCallStack"
                                 ]
 


### PR DESCRIPTION
This PR adds a `CallStack` entry to `catch`, which should aid error diagnosis.

Before submitting your PR, check that you've:

- [x] Bumped the version number.
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html).
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock.
- [x] Ran `stylish-haskell` and otherwise adhered to the [style guide](https://github.com/bitemyapp/esqueleto/blob/master/style-guide.yaml).

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR.
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts).

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_

If you're unsure on what the new version number should be, feel free to ask.

-->
