### PR TITLE
`flatten` handles `CallStack`s

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,40 +1,71 @@
-name: CI
+name: build
 on:
   push:
-    branches:
-      - master
+    branches: [main, master]
   pull_request:
-    types:
-      - opened
-      - synchronize
+    branches: [main, master]
+
+permissions:
+  contents: read
+
 jobs:
   build:
-    runs-on: ubuntu-latest
+    name: GHC ${{ matrix.ghc-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        cabal: ["3.6"]
-        ghc: ["8.6.5", "8.8.4", "8.10.7", "9.0.2", "9.2.4", "9.4.1"]
-    env:
-      CONFIG: "--enable-tests"
+        os: [ubuntu-latest]
+        ghc-version: ['9.6', '9.4', '9.2', '9.0', '8.10', '8.8', '8.6']
+
     steps:
-      - uses: actions/checkout@v2
-      - uses: haskell/actions/setup@v1
-        id: setup-haskell-cabal
+      - uses: actions/checkout@v3
+
+      - name: Set up GHC ${{ matrix.ghc-version }}
+        uses: haskell/actions/setup@v2
+        id: setup
         with:
-          ghc-version: ${{ matrix.ghc }}
-          cabal-version: ${{ matrix.cabal }}
-      - run: cabal v2-update
-      - run: cabal v2-freeze $CONFIG
-        #       - uses: actions/cache@v2
-        #         with:
-        #           path: |
-        #             ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
-        #             dist-newstyle
-        #           key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
-        #           restore-keys: |
-        #             ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
-        #             ${{ runner.os }}-${{ matrix.ghc }}-
-      - run: cabal v2-build --disable-optimization -j $CONFIG
-      - run: cabal v2-test --disable-optimization -j $CONFIG
-      - run: cabal v2-haddock -j $CONFIG
-      - run: cabal v2-sdist
+          ghc-version: ${{ matrix.ghc-version }}
+          # Defaults, added for clarity:
+          cabal-version: 'latest'
+          cabal-update: true
+
+      - name: Configure the build
+        run: |
+          cabal configure --enable-tests --enable-benchmarks --disable-documentation
+          cabal build --dry-run
+        # The last step generates dist-newstyle/cache/plan.json for the cache key.
+
+      - name: Restore cached dependencies
+        uses: actions/cache/restore@v3
+        id: cache
+        env:
+          key: ${{ runner.os }}-ghc-${{ steps.setup.outputs.ghc-version }}-cabal-${{ steps.setup.outputs.cabal-version }}
+        with:
+          path: ${{ steps.setup.outputs.cabal-store }}
+          key: ${{ env.key }}-plan-${{ hashFiles('**/plan.json') }}
+          restore-keys: ${{ env.key }}-
+
+      - name: Install dependencies
+        run: cabal build all --only-dependencies
+
+      # Cache dependencies already here, so that we do not have to rebuild them should the subsequent steps fail.
+      - name: Save cached dependencies
+        uses: actions/cache/save@v3
+        # Caches are immutable, trying to save with the same key would error.
+        if: ${{ steps.cache.outputs.cache-primary-key != steps.cache.outputs.cache-matched-key }}
+        with:
+          path: ${{ steps.setup.outputs.cabal-store }}
+          key: ${{ steps.cache.outputs.cache-primary-key }}
+
+      - name: Build
+        run: cabal build all
+
+      - name: Run tests
+        run: cabal test all
+
+      - name: Check cabal file
+        run: cabal check
+
+      - name: Build documentation
+        run: cabal haddock all

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .stack-work/
 *~
+
+dist/
+dist-newstyle/

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,11 @@
 # Changelog for `annotated-exception`
 
+## 0.2.0.5
+
+- []()
+    - Ensure that `flatten` combines `CallStack`s even when the callstack is
+      attached manually.
+
 ## 0.2.0.4
 
 - [#18](https://github.com/parsonsmatt/annotated-exception/pull/18)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## 0.2.0.5
 
-- []()
+- [#27](https://github.com/parsonsmatt/annotated-exception/pull/27)
     - Ensure that `flatten` combines `CallStack`s even when the callstack is
       attached manually.
 

--- a/annotated-exception.cabal
+++ b/annotated-exception.cabal
@@ -1,11 +1,11 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
 
 name:           annotated-exception
-version:        0.2.0.4
+version:        0.2.0.5
 synopsis:       Exceptions, with checkpoints and context.
 description:    Please see the README on Github at <https://github.com/parsonsmatt/annotated-exception#readme>
 category:       Control

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                annotated-exception
-version:             0.2.0.4
+version:             0.2.0.5
 github:              "parsonsmatt/annotated-exception"
 license:             BSD3
 author:              "Matt Parsons"

--- a/src/Control/Exception/Annotated.hs
+++ b/src/Control/Exception/Annotated.hs
@@ -57,6 +57,7 @@ module Control.Exception.Annotated
     , Handler (..)
     ) where
 
+import Control.Applicative ((<|>))
 import Control.Exception.Safe
        (Exception, Handler(..), MonadCatch, MonadThrow, SomeException(..))
 import qualified Control.Exception.Safe as Safe
@@ -65,7 +66,6 @@ import Data.Maybe
 import qualified Data.Set as Set
 import Data.Typeable
 import GHC.Stack
-import Control.Applicative ((<|>))
 
 -- | The 'AnnotatedException' type wraps an @exception@ with
 -- a @['Annotation']@. This can provide a sort of a manual stack trace with

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-17.1
+resolver: lts-21.10

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 563098
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/17/1.yaml
-    sha256: 395775c03e66a4286f134d50346b0b6f1432131cf542886252984b4cfa5fef69
-  original: lts-17.1
+    sha256: 1fc72fa74175fa3937b04c648229d601074183539a6f3d5cd49e99561873d79f
+    size: 640039
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/21/10.yaml
+  original: lts-21.10

--- a/test/Control/Exception/AnnotatedSpec.hs
+++ b/test/Control/Exception/AnnotatedSpec.hs
@@ -487,7 +487,7 @@ shouldBeWithoutCallStackInAnnotations (AnnotatedException exp e0) e1 = do
     filterCallStack anns =
         snd $ tryAnnotations @CallStack anns
 
-shouldHaveAtMostOneCallStack :: [Annotation] -> IO ()
+shouldHaveAtMostOneCallStack :: HasCallStack => [Annotation] -> IO ()
 shouldHaveAtMostOneCallStack anns =
     if (length (fst (tryAnnotations anns) :: [CallStack]) > 1)
     then expectationFailure $ "has too many callstacks: " ++ show anns


### PR DESCRIPTION
Fixes #23 

This PR adjusts `flatten` so that it appropriately handles `CallStack`s. Before this, you could get into trouble like this:

```haskell
flatten (AnnotatedException [callStackAnnotation] (AnnotatedException [callStackAnnotation] TestException))
    = AnnotatedException [callStackAnnotation, callStackAnnotation] TestException
```

After this PR, the above will evaluate to:

```haskell
flatten (AnnotatedException [callStackAnnotation] (AnnotatedException [callStackAnnotation] TestException))
    = AnnotatedException [mergeCallStacks callStackAnnotation callStackAnnotation] TestException
```

Before submitting your PR, check that you've:

- [x] Bumped the version number.
- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html).
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock.
- [ ] Ran `stylish-haskell` and otherwise adhered to the [style guide](https://github.com/bitemyapp/esqueleto/blob/master/style-guide.yaml).

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR.
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts).

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_

If you're unsure on what the new version number should be, feel free to ask.

-->
