### PR TITLE
Custom `displayException` 

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,11 @@
 # Changelog for `annotated-exception`
 
+## 0.3.0.0
+
+- [#30](https://github.com/parsonsmatt/annotated-exception/pull/30)
+    - The `Show` and `displayException` now render the annotated exception in a
+      much nicer way.
+
 ## 0.2.0.5
 
 - [#27](https://github.com/parsonsmatt/annotated-exception/pull/27)

--- a/annotated-exception.cabal
+++ b/annotated-exception.cabal
@@ -1,11 +1,11 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.2.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 
 name:           annotated-exception
-version:        0.2.0.5
+version:        0.3.0.0
 synopsis:       Exceptions, with checkpoints and context.
 description:    Please see the README on Github at <https://github.com/parsonsmatt/annotated-exception#readme>
 category:       Control

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                annotated-exception
-version:             0.2.0.5
+version:             0.3.0.0
 github:              "parsonsmatt/annotated-exception"
 license:             BSD3
 author:              "Matt Parsons"

--- a/src/Control/Exception/Annotated.hs
+++ b/src/Control/Exception/Annotated.hs
@@ -78,7 +78,10 @@ data AnnotatedException exception
     { annotations :: [Annotation]
     , exception   :: exception
     }
-    deriving (Show, Functor, Foldable, Traversable)
+    deriving (Functor, Foldable, Traversable)
+
+instance (Exception exception) => Show (AnnotatedException exception) where
+    show = Safe.displayException
 
 instance Applicative AnnotatedException where
     pure =

--- a/src/Control/Exception/Annotated.hs
+++ b/src/Control/Exception/Annotated.hs
@@ -118,6 +118,31 @@ instance (Exception exception) => Exception (AnnotatedException exception) where
         =
             Nothing
 
+    displayException annE@(AnnotatedException annotations exception) =
+        unlines
+            [ "! AnnotatedException !"
+            , "Underlying exception type: " <> show (typeOf exception)
+            , "displayException:"
+            , "\t" <> Safe.displayException exception
+            ]
+        <> annotationsMessage
+        <> callStackMessage
+      where
+        (callStacks, otherAnnotations) = tryAnnotations @CallStack annotations
+        callStackMessage =
+            case listToMaybe callStacks of
+                Nothing ->
+                    "(no callstack available)"
+                Just cs ->
+                    prettyCallStack cs
+        annotationsMessage =
+            case otherAnnotations of
+                [] ->
+                    "\n"
+                anns ->
+                    "Annotations:\n"
+                    <> unlines (map (\ann -> "\t * " <> show ann) anns)
+
 -- | Annotate the underlying exception with a 'CallStack'.
 --
 -- @since 0.2.0.0

--- a/test/Control/Exception/AnnotatedSpec.hs
+++ b/test/Control/Exception/AnnotatedSpec.hs
@@ -55,6 +55,29 @@ spec = do
                     SomeException $
                         AnnotatedException ["hello", "goodbye"] (SomeException TestException)
 
+    describe "displayException" $ do
+        it "is reasonably nice to look at" $ do
+            lines (displayException (AnnotatedException [] TestException))
+                `shouldBe`
+                    [ "! AnnotatedException !"
+                    , "Underlying exception type: TestException"
+                    , "displayException:"
+                    , "\tTestException"
+                    , ""
+                    , "(no callstack available)"
+                    ]
+        it "is reasonably nice to look at" $ do
+            lines (displayException (AnnotatedException [Annotation @String "asdf"] TestException))
+                `shouldBe`
+                    [ "! AnnotatedException !"
+                    , "Underlying exception type: TestException"
+                    , "displayException:"
+                    , "\tTestException"
+                    , "Annotations:"
+                    , "\t * Annotation @[Char] \"asdf\""
+                    , "(no callstack available)"
+                    ]
+
     describe "AnnotatedException can fromException a" $ do
         it "different type" $ do
             fromException (toException TestException)


### PR DESCRIPTION
This PR changes `displayException` here to be *significantly* better.

Before submitting your PR, check that you've:

- [x] Bumped the version number.
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html).
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock.
- [x] Ran `stylish-haskell` and otherwise adhered to the [style guide](https://github.com/bitemyapp/esqueleto/blob/master/style-guide.yaml).

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR.
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts).

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_

If you're unsure on what the new version number should be, feel free to ask.

-->
