### PR TITLE
use newer ghc in ci

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ghc-version: ['9.10', '9.8', '9.6', '9.4', '9.2', '9.0', '8.10', '8.8', '8.6']
+        ghc-version: ['9.8', '9.6', '9.4', '9.2', '9.0', '8.10', '8.8', '8.6']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ghc-version: ['9.8', '9.6', '9.4', '9.2', '9.0', '8.10', '8.8', '8.6']
+        ghc-version: ['9.10', '9.8', '9.6', '9.4', '9.2', '9.0', '8.10', '8.8', '8.6']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ghc-version: ['9.6', '9.4', '9.2', '9.0', '8.10', '8.8', '8.6']
+        ghc-version: ['9.10', '9.8', '9.6', '9.4', '9.2', '9.0', '8.10', '8.8', '8.6']
 
     steps:
       - uses: actions/checkout@v3

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .stack-work/
 *~
 
+cabal.project.local
 dist/
 dist-newstyle/

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog for `annotated-exception`
 
+## 0.3.0.2
+
+- []()
+    - Fixed the tests for GHC 9.10
+
 ## 0.3.0.1
 
 - [#31](https://github.com/parsonsmatt/annotated-exception/pull/31)

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                annotated-exception
-version:             0.3.0.1
+version:             0.3.0.2
 github:              "parsonsmatt/annotated-exception"
 license:             BSD3
 author:              "Matt Parsons"

--- a/test/Control/Exception/AnnotatedSpec.hs
+++ b/test/Control/Exception/AnnotatedSpec.hs
@@ -37,6 +37,9 @@ pass = pure ()
 emptyAnnotation :: e -> AnnotatedException e
 emptyAnnotation = pure
 
+omitEmptyLines :: String -> [String]
+omitEmptyLines = filter (/= "") . lines
+
 spec :: Spec
 spec = do
     describe "toException" $ do
@@ -56,18 +59,18 @@ spec = do
                         AnnotatedException ["hello", "goodbye"] (SomeException TestException)
 
     describe "displayException" $ do
+        it "is identical on SomeException" $ do
+            omitEmptyLines (displayException TestException)
+                `shouldBe` omitEmptyLines (displayException (SomeException TestException))
         it "is reasonably nice to look at" $ do
-            lines (displayException (AnnotatedException [] TestException))
+            omitEmptyLines (displayException (AnnotatedException [] TestException))
                 `shouldBe`
                     [ "! AnnotatedException !"
                     , "Underlying exception type: TestException"
-                    , ""
                     , "show:"
                     , "\tTestException"
-                    , ""
                     , "displayException:"
                     , "\tTestException"
-                    , ""
                     , "(no callstack available)"
                     ]
         it "is reasonably nice to look at" $ do
@@ -90,16 +93,14 @@ spec = do
             let resultLines =
                     [ "! AnnotatedException !"
                     , "Underlying exception type: TestException"
-                    , ""
                     , "show:"
                     , "\tTestException"
-                    , ""
                     , "displayException:"
                     , "\tTestException"
                     , "Annotations:"
                     , "\t * Annotation @[Char] \"asdf\""
                     ]
-            take (length resultLines) (lines (displayException (exn :: AnnotatedException SomeException))) `shouldBe`
+            take (length resultLines) (omitEmptyLines (displayException (exn :: AnnotatedException SomeException))) `shouldBe`
                 resultLines
 
     describe "AnnotatedException can fromException a" $ do


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [ ] Bumped the version number.
- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html).
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock.
- [ ] Ran `stylish-haskell` and otherwise adhered to the [style guide](https://github.com/bitemyapp/esqueleto/blob/master/style-guide.yaml).

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR.
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts).

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_

If you're unsure on what the new version number should be, feel free to ask.

-->
