### PR TITLE
Deduplicate, reorder `displayException` impl

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog for `annotated-exception`
 
+## 0.3.0.3
+
+- [#36](https://github.com/parsonsmatt/annotated-exception/pull/36)
+    - Improved the `AnotatedException` `displayException` implementation.
+
 ## 0.3.0.2
 
 - [#32](https://github.com/parsonsmatt/annotated-exception/pull/32)

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                annotated-exception
-version:             0.3.0.2
+version:             0.3.0.3
 github:              "parsonsmatt/annotated-exception"
 license:             BSD3
 author:              "Matt Parsons"


### PR DESCRIPTION
The default `displayException = show` implementation is often used, leading to duplicated output in the `AnnotatedException` `displayException` implementation.

Here we make a couple tweaks to that implementation:

1. If `show` and `displayException` return the same output, only one is used.
2. If only the `displayException` output is shown, it's not indented.
3. If both the `displayException` and `show` output is shown, the `displayException` output is shown first.
4. There is a blank line before the "Annotations:" section, to match the blank line between the `displayException` and `show` output.
5. There is a blank line before the call stack section.

Before submitting your PR, check that you've:

- [x] Bumped the version number.
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html).
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock.
- [x] Ran `stylish-haskell` and otherwise adhered to the [style guide](https://github.com/bitemyapp/esqueleto/blob/master/style-guide.yaml).

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR.
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts).

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_

If you're unsure on what the new version number should be, feel free to ask.

-->
