### PR TITLE
displayException: Remove trailing newline

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,12 @@
 # Changelog for `annotated-exception`
 
+## 0.3.0.4
+
+- [#37](https://github.com/parsonsmatt/annotated-exception/pull/37)
+    - Removed a trailing newline from the `AnnotatedException`
+      `displayException` implementation (this was a regression introduced in
+      0.3.0.3).
+
 ## 0.3.0.3
 
 - [#36](https://github.com/parsonsmatt/annotated-exception/pull/36)

--- a/annotated-exception.cabal
+++ b/annotated-exception.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           annotated-exception
-version:        0.3.0.3
+version:        0.3.0.4
 synopsis:       Exceptions, with checkpoints and context.
 description:    Please see the README on Github at <https://github.com/parsonsmatt/annotated-exception#readme>
 category:       Control

--- a/src/Control/Exception/Annotated.hs
+++ b/src/Control/Exception/Annotated.hs
@@ -63,6 +63,7 @@ import Control.Exception.Safe
        (Exception, Handler(..), MonadCatch, MonadThrow, SomeException(..))
 import qualified Control.Exception.Safe as Safe
 import Data.Annotation
+import Data.List (intersperse)
 import Data.Maybe
 import qualified Data.Set as Set
 import Data.Typeable
@@ -123,7 +124,7 @@ instance (Exception exception) => Exception (AnnotatedException exception) where
             Nothing
 
     displayException (AnnotatedException{..}) =
-        unlines $
+        concat $ intersperse "\n" $
             [ "! AnnotatedException !"
             , "Underlying exception type: " <> show exceptionType
             , ""


### PR DESCRIPTION
In #36, I restructured the `AnnotatedException` `displayException` implementation so that instead of being of the form:

    displayException =
        unlines [ ... ] <> callStackMessage
        where
            callStackMessage = prettyCallStack frames

It was of the form:

    displayException =
        unlines $ [ ... ] <> callStackMessage
        where
            callStackMessage = [prettyCallStack frames]

I didn't realize that `unlines` adds a trailing newline, which is generally the wrong behavior for `displayException` instances.

This change replaces `unlines` with `concat . intersperse "\n"` in order to regain the correct behavior.

Before submitting your PR, check that you've:

- [x] Bumped the version number.
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html).
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock.
- [x] Ran `stylish-haskell` and otherwise adhered to the [style guide](https://github.com/bitemyapp/esqueleto/blob/master/style-guide.yaml).

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR.
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts).

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_

If you're unsure on what the new version number should be, feel free to ask.

-->
